### PR TITLE
check in go.mod/go.sum, add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+/.git
+/.gitignore
+/.travis.yml
+
+/processors/testfeed
+/processors/testfeed-*
+/**/*_test.go
+/gtfstidy

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.swp
+
+/gtfstidy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:alpine AS builder
+WORKDIR /src
+
+RUN apk add --no-cache --update git
+
+COPY go.mod go.sum *.go ./
+COPY processors/ ./processors/
+
+RUN go get
+RUN CGO_ENABLED=0 go build -o /usr/local/bin/gtfstidy
+
+FROM scratch
+LABEL org.opencontainers.image.title="gtfstidy"
+LABEL org.opencontainers.image.description="A tool for checking, sanitizing and minimizing GTFS feeds."
+LABEL org.opencontainers.image.authors="Patrick Brosi <info@patrickbrosi.de>"
+LABEL org.opencontainers.image.documentation="https://github.com/patrickbr/gtfstidy"
+LABEL org.opencontainers.image.source="https://github.com/patrickbr/gtfstidy"
+LABEL org.opencontainers.image.revision="v0.2"
+LABEL org.opencontainers.image.licenses="GPL-2.0"
+
+COPY --from=builder /usr/local/bin/gtfstidy /usr/local/bin/gtfstidy
+
+ENTRYPOINT ["/usr/local/bin/gtfstidy"]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/patrickbr/gtfstidy
+
+go 1.16
+
+require (
+	github.com/patrickbr/gtfsparser v0.0.0-20210503211936-d06c485ba62b
+	github.com/patrickbr/gtfswriter v0.0.0-20210407163711-6625630376c8
+	github.com/spf13/pflag v1.0.5
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/patrickbr/gtfsparser v0.0.0-20210503211936-d06c485ba62b h1:C9TB1Jd8i2Q+Mii0VufGWRY/70n+9UUfslAd/Spz4yU=
+github.com/patrickbr/gtfsparser v0.0.0-20210503211936-d06c485ba62b/go.mod h1:L88c76QEIfk3Z5pr1S715jfv1EIEVZ7BvNiefxz4o3o=
+github.com/patrickbr/gtfswriter v0.0.0-20210407163711-6625630376c8 h1:rennEshiJjXDi7r9FTZjz1yUY0jFxWWGNVuNCdSsnVw=
+github.com/patrickbr/gtfswriter v0.0.0-20210407163711-6625630376c8/go.mod h1:zYAfZRXtDhc4Tq+LYrvyksefggNiViL2pKMRUrGvUbE=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=


### PR DESCRIPTION
Even though the binaries work great as a low-effort way to run `gtfstidy` on some GTFS feeds, in some environments (e.g. CIs) using Docker is more straightforward.

still missing:

- [x] add [metadata](https://github.com/opencontainers/image-spec/blob/859973e32ccae7b7fc76b40b762c9fff6e912f9e/annotations.md#pre-defined-annotation-keys) to the Docker image
- [ ] let the CI build & publish the Docker image?

---

This is a follow-up PR on #8, which I have accidentally closed.