### PR TITLE
Don't remove orphan stop if it's entrance/exit

### DIFF
--- a/processors/orphanminimizer.go
+++ b/processors/orphanminimizer.go
@@ -150,7 +150,7 @@ func (or OrphanRemover) removeStopOrphans(feed *gtfsparser.Feed) {
 
 	// delete unreferenced
 	for id, s := range feed.Stops {
-		if _, in := referenced[s]; !in {
+		if _, in := referenced[s]; !in && s.Location_type != 2 {
 			feed.DeleteStop(id)
 		}
 	}


### PR DESCRIPTION
Entrance/exits won't be assigned in stop_times and will thus be "orphans". They should not however be removed since they serve another purpose. What's your opinion on this?