### PR TITLE
Typo && Test cases fixed

### DIFF
--- a/gtfstidy.go
+++ b/gtfstidy.go
@@ -185,7 +185,7 @@ func main() {
 	flag.StringArrayVar(&polygonFiles, "polygon-file", []string{}, "polygon filter, as a file containing comma separated latitude,longitude pairs (multiple polygons allowed by defining --polygon-file multiple times), or a GeoJSON file ending with .geojson or .json")
 	showWarnings := flag.BoolP("show-warnings", "W", false, "show warnings")
 	minHeadway := flag.IntP("min-headway", "", 1, "min allowed headway (in seconds) for frequency found with -T")
-	maxHeadway := flag.IntP("max-headway", "", 3600*24, "min allowed headway (in seconds) for frequency found with -T")
+	maxHeadway := flag.IntP("max-headway", "", 3600*24, "max allowed headway (in seconds) for frequency found with -T")
 	zipCompressionLevel := flag.IntP("zip-compression-level", "", 9, "output ZIP file compression level, between 0 and 9")
 	dontSortZipFiles := flag.BoolP("unsorted-files", "", false, "don't sort the output ZIP files (might increase final ZIP size)")
 	useStandardRouteTypes := flag.BoolP("standard-route-types", "", false, "Always use standard route types")

--- a/processors/shapeminimizer_test.go
+++ b/processors/shapeminimizer_test.go
@@ -47,7 +47,7 @@ func TestShapeMinimizer(t *testing.T) {
 		t.Error(feed.Shapes["A_shp"].Points[2])
 	}
 
-	if !(shapePointEquals(feed.Shapes["A_shp"].Points[3], gtfs.ShapePoint{Lat: 3.5, Lon: 1, Dist_traveled: 42.910156})) {
+	if !(shapePointEquals(feed.Shapes["A_shp"].Points[3], gtfs.ShapePoint{Lat: 3.5, Lon: 1, Dist_traveled: 42.902325})) {
 		t.Error(feed.Shapes["A_shp"].Points[3])
 	}
 
@@ -63,7 +63,7 @@ func TestShapeMinimizer(t *testing.T) {
 		t.Error(feed.Shapes["B_shp"].Points[2])
 	}
 
-	if !(shapePointEquals(feed.Shapes["B_shp"].Points[3], gtfs.ShapePoint{Lat: 3.5, Lon: 1, Dist_traveled: 42.910156})) {
+	if !(shapePointEquals(feed.Shapes["B_shp"].Points[3], gtfs.ShapePoint{Lat: 3.5, Lon: 1, Dist_traveled: 42.902325})) {
 		t.Error(feed.Shapes["B_shp"].Points[3])
 	}
 }


### PR DESCRIPTION
Hey @patrickbr,

I actually wanted to add a functionality that is not yet available in the current release version; but then when I built the current Github version there was the option “--keep-mots string” :)

I found a small copy-paste typo in the one of the arguments, but when I built the project, I ran into the following issue #33 .

Kind regards,
Patrick