### PR TITLE
Fix intermediate stops along trip headsign

### DIFF
--- a/gtfstidy.go
+++ b/gtfstidy.go
@@ -9,17 +9,18 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/patrickbr/gtfsparser"
-	"github.com/patrickbr/gtfsparser/gtfs"
-	"github.com/patrickbr/gtfstidy/processors"
-	"github.com/patrickbr/gtfswriter"
-	"github.com/paulmach/go.geojson"
-	flag "github.com/spf13/pflag"
 	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
 	"strings"
+
+	"github.com/patrickbr/gtfsparser"
+	"github.com/patrickbr/gtfsparser/gtfs"
+	"github.com/patrickbr/gtfstidy/processors"
+	"github.com/patrickbr/gtfswriter"
+	geojson "github.com/paulmach/go.geojson"
+	flag "github.com/spf13/pflag"
 )
 
 func getGtfsPoly(poly [][][]float64) gtfsparser.Polygon {
@@ -170,6 +171,7 @@ func main() {
 	explicitCals := flag.BoolP("explicit-calendar", "", false, "add calendar.txt entry for every service, even irregular ones")
 	ensureTripHeadsigns := flag.BoolP("ensure-trip-headsigns", "", false, "write trip headsigns if missing")
 	ensureParents := flag.BoolP("ensure-stop-parents", "", false, "ensure that every stop (location_type=0) has a parent station")
+	fixTripHeadsigns := flag.BoolP("fix-trip-headsigns", "", false, "fixes trip headsigns pointing to previous stops")
 	keepColOrder := flag.BoolP("keep-col-order", "", false, "keep the original column ordering of the input feed")
 	keepFields := flag.BoolP("keep-additional-fields", "F", false, "keep all non-GTFS fields from the input")
 	dropTooFast := flag.BoolP("drop-too-fast-trips", "", false, "drop trips that are too fast to realistically occur")
@@ -640,6 +642,9 @@ func main() {
 
 		if *ensureTripHeadsigns {
 			minzers = append(minzers, processors.TripHeadsigner{})
+		}
+		if *fixTripHeadsigns {
+			minzers = append(minzers, processors.FixIntermediateHeadsigns{})
 		}
 
 		if *useRedTripMinimizer {

--- a/processors/intermediateheadsign.go
+++ b/processors/intermediateheadsign.go
@@ -45,6 +45,7 @@ func (pro FixIntermediateHeadsigns) Run(feed *gtfsparser.Feed) {
 			st := trip.StopTimes[i]
 			if st.Stop() != nil && st.Stop().Name == *currentHeadsign {
 				matchIndex = i
+				break
 			}
 		}
 

--- a/processors/intermediateheadsign.go
+++ b/processors/intermediateheadsign.go
@@ -45,7 +45,6 @@ func (pro FixIntermediateHeadsigns) Run(feed *gtfsparser.Feed) {
 			st := trip.StopTimes[i]
 			if st.Stop() != nil && st.Stop().Name == *currentHeadsign {
 				matchIndex = i
-				break
 			}
 		}
 

--- a/processors/intermediateheadsign.go
+++ b/processors/intermediateheadsign.go
@@ -41,10 +41,11 @@ func (pro FixIntermediateHeadsigns) Run(feed *gtfsparser.Feed) {
 		matchIndex := -1
 
 		// 1. Check if headsign is equal to a stop along the trip (except the last one)
-		for i := 0; i < len(trip.StopTimes)-1; i++ {
+		for i := len(trip.StopTimes) - 2; i >= 0; i-- {
 			st := trip.StopTimes[i]
 			if st.Stop() != nil && st.Stop().Name == *currentHeadsign {
 				matchIndex = i
+				break
 			}
 		}
 

--- a/processors/intermediateheadsign.go
+++ b/processors/intermediateheadsign.go
@@ -41,11 +41,8 @@ func (pro FixIntermediateHeadsigns) Run(feed *gtfsparser.Feed) {
 		matchIndex := -1
 
 		// 1. Check if headsign is equal to a stop along the trip (except the last one)
-		for i, st := range trip.StopTimes {
-			if i == lastStopIdx {
-				break
-			}
-
+		for i := 0; i < len(trip.StopTimes)-1; i++ {
+			st := trip.StopTimes[i]
 			if st.Stop() != nil && st.Stop().Name == *currentHeadsign {
 				matchIndex = i
 			}

--- a/processors/intermediateheadsign.go
+++ b/processors/intermediateheadsign.go
@@ -1,0 +1,74 @@
+package processors
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/patrickbr/gtfsparser"
+)
+
+// FixIntermediateHeadsigns checks if the trip headsign matches an intermediate stop.
+// If so, it sets the stop_headsign for previous stops to that intermediate name
+// and updates the trip_headsign to the final destination.
+
+type FixIntermediateHeadsigns struct{}
+
+func (pro FixIntermediateHeadsigns) Run(feed *gtfsparser.Feed) {
+	fmt.Fprintf(os.Stdout, "Fixing intermediate headsigns... ")
+
+	count := 0
+
+	for _, trip := range feed.Trips {
+		if len(trip.StopTimes) < 2 {
+			continue
+		}
+
+		currentHeadsign := trip.Headsign
+		if *currentHeadsign == "" {
+			continue
+		}
+
+		lastStopIdx := len(trip.StopTimes) - 1
+		lastStop := trip.StopTimes[lastStopIdx].Stop()
+		if lastStop == nil {
+			continue
+		}
+
+		if *currentHeadsign == lastStop.Name {
+			continue
+		}
+
+		matchIndex := -1
+
+		// 1. Check if headsign is equal to a stop along the trip (except the last one)
+		for i, st := range trip.StopTimes {
+			if i == lastStopIdx {
+				break
+			}
+
+			if st.Stop() != nil && st.Stop().Name == *currentHeadsign {
+				matchIndex = i
+			}
+		}
+
+		if matchIndex != -1 {
+			// Logic:
+			// Sequence: A -> B -> C (match) -> D -> E (last)
+			// Old Trip Headsign: C
+			// New Trip Headsign: E
+			// Stop Headsign for A, B: C
+
+			// Update trip headsign to the actual last stop
+			trip.Headsign = &lastStop.Name
+
+			// Update stop_headsign for all stops prior to the match
+			for j := 0; j < matchIndex; j++ {
+				trip.StopTimes[j].SetHeadsign(currentHeadsign)
+			}
+
+			count++
+		}
+	}
+
+	fmt.Fprintf(os.Stdout, "done. Fixed headsigns for %d trips.\n", count)
+}

--- a/processors/intermediateheadsign.go
+++ b/processors/intermediateheadsign.go
@@ -56,8 +56,10 @@ func (pro FixIntermediateHeadsigns) Run(feed *gtfsparser.Feed) {
 			// New Trip Headsign: E
 			// Stop Headsign for A, B: C
 
-			// Update trip headsign to the actual last stop
-			trip.Headsign = &lastStop.Name
+			// Update trip headsign to the actual last stop.
+			// Copy the string to avoid aliasing into the Stop struct
+			lastStopName := lastStop.Name
+			trip.Headsign = &lastStopName
 
 			// Update stop_headsign for all stops prior to the match
 			for j := 0; j < matchIndex; j++ {

--- a/processors/intermediateheadsign_test.go
+++ b/processors/intermediateheadsign_test.go
@@ -1,0 +1,277 @@
+package processors
+
+import (
+	"testing"
+
+	"github.com/patrickbr/gtfsparser"
+	"github.com/patrickbr/gtfsparser/gtfs"
+)
+
+// makeStr is a helper that returns a pointer to a string literal.
+func makeStr(s string) *string {
+	return &s
+}
+
+// buildFeed constructs a minimal Feed containing a single trip. The caller
+// supplies the trip headsign and a slice of stop names in travel order; the
+// function wires up the corresponding Stop and StopTime objects.
+func buildFeed(headsign string, stopNames []string) *gtfsparser.Feed {
+	feed := gtfsparser.NewFeed()
+
+	// Build stops.
+	stops := make([]*gtfs.Stop, len(stopNames))
+	for i, name := range stopNames {
+		name := name // capture
+		s := &gtfs.Stop{Id: name, Name: name}
+		stops[i] = s
+		feed.Stops[name] = s
+	}
+
+	// Build trip with stop times.
+	trip := &gtfs.Trip{
+		Id:       "trip1",
+		Headsign: makeStr(headsign),
+	}
+	for i, stop := range stops {
+		var st gtfs.StopTime
+		st.SetStop(stop)
+		st.SetSequence(i + 1)
+		trip.StopTimes = append(trip.StopTimes, st)
+	}
+
+	feed.Trips["trip1"] = trip
+	return feed
+}
+
+// tripOf returns the single trip in a feed built by buildFeed.
+func tripOf(feed *gtfsparser.Feed) *gtfs.Trip {
+	return feed.Trips["trip1"]
+}
+
+// ---- Tests ------------------------------------------------------------------
+
+// TestHeadsignAlreadyLastStop: headsign already matches the final stop —
+// nothing should change.
+func TestHeadsignAlreadyLastStop(t *testing.T) {
+	feed := buildFeed("Rapperswil", []string{"Zürich", "St. Gallen", "Rapperswil"})
+	FixIntermediateHeadsigns{}.Run(feed)
+
+	trip := tripOf(feed)
+	if *trip.Headsign != "Rapperswil" {
+		t.Errorf("expected headsign to stay %q, got %q", "Rapperswil", *trip.Headsign)
+	}
+	for i := range trip.StopTimes {
+		if trip.StopTimes[i].Headsign() != nil {
+			t.Errorf("stop %d: expected nil stop_headsign, got %q", i, *trip.StopTimes[i].Headsign())
+		}
+	}
+}
+
+// TestHeadsignMatchesIntermediateStop: the Swiss bug — headsign points to an
+// intermediate stop. The processor should update the trip headsign to the last
+// stop and set stop_headsign on all preceding stops.
+func TestHeadsignMatchesIntermediateStop(t *testing.T) {
+	// Route: Zürich → St. Gallen → Rapperswil
+	// Headsign is "St. Gallen" (intermediate).
+	feed := buildFeed("St. Gallen", []string{"Zürich", "St. Gallen", "Rapperswil"})
+	FixIntermediateHeadsigns{}.Run(feed)
+
+	trip := tripOf(feed)
+
+	// Trip headsign must now be the last stop.
+	if *trip.Headsign != "Rapperswil" {
+		t.Errorf("expected trip headsign %q, got %q", "Rapperswil", *trip.Headsign)
+	}
+
+	// Stops before the matched intermediate stop should carry the old headsign.
+	// Index 0 = "Zürich" (before match at index 1) → should have stop_headsign "St. Gallen".
+	if trip.StopTimes[0].Headsign() == nil || *trip.StopTimes[0].Headsign() != "St. Gallen" {
+		got := "<nil>"
+		if trip.StopTimes[0].Headsign() != nil {
+			got = *trip.StopTimes[0].Headsign()
+		}
+		t.Errorf("stop 0: expected stop_headsign %q, got %q", "St. Gallen", got)
+	}
+
+	// Index 1 = the matched stop itself — no stop_headsign should be set.
+	if trip.StopTimes[1].Headsign() != nil {
+		t.Errorf("stop 1 (match): expected nil stop_headsign, got %q", *trip.StopTimes[1].Headsign())
+	}
+
+	// Index 2 = last stop — no stop_headsign.
+	if trip.StopTimes[2].Headsign() != nil {
+		t.Errorf("stop 2 (last): expected nil stop_headsign, got %q", *trip.StopTimes[2].Headsign())
+	}
+}
+
+// TestHeadsignNotInTrip: headsign doesn't match any stop in the trip —
+// nothing should change.
+func TestHeadsignNotInTrip(t *testing.T) {
+	feed := buildFeed("Geneva", []string{"Zürich", "Bern", "Lausanne"})
+	FixIntermediateHeadsigns{}.Run(feed)
+
+	trip := tripOf(feed)
+	if *trip.Headsign != "Geneva" {
+		t.Errorf("expected headsign to stay %q, got %q", "Geneva", *trip.Headsign)
+	}
+	for i := range trip.StopTimes {
+		if trip.StopTimes[i].Headsign() != nil {
+			t.Errorf("stop %d: expected nil stop_headsign, got %q", i, *trip.StopTimes[i].Headsign())
+		}
+	}
+}
+
+// TestEmptyHeadsign: empty trip headsign — processor should skip the trip.
+func TestEmptyHeadsign(t *testing.T) {
+	feed := buildFeed("", []string{"A", "B", "C"})
+	FixIntermediateHeadsigns{}.Run(feed)
+
+	trip := tripOf(feed)
+	if *trip.Headsign != "" {
+		t.Errorf("expected headsign to stay empty, got %q", *trip.Headsign)
+	}
+}
+
+// TestSingleStopTrip: only one stop — processor should skip (no room for an
+// intermediate match).
+func TestSingleStopTrip(t *testing.T) {
+	feed := buildFeed("Terminus", []string{"Terminus"})
+	FixIntermediateHeadsigns{}.Run(feed)
+
+	trip := tripOf(feed)
+	if *trip.Headsign != "Terminus" {
+		t.Errorf("expected headsign to stay %q, got %q", "Terminus", *trip.Headsign)
+	}
+}
+
+// TestTwoStopTrip: two stops — headsign matching the first (only intermediate)
+// stop should be corrected.
+func TestTwoStopTrip(t *testing.T) {
+	// Route: A → B. Headsign is "A" (the first and only intermediate stop).
+	feed := buildFeed("A", []string{"A", "B"})
+	FixIntermediateHeadsigns{}.Run(feed)
+
+	trip := tripOf(feed)
+	if *trip.Headsign != "B" {
+		t.Errorf("expected trip headsign %q, got %q", "B", *trip.Headsign)
+	}
+	// Stop 0 ("A") is the match; it sits at index 0, so matchIndex == 0.
+	// No stops precede it, so no stop_headsigns should be set.
+	for i := range trip.StopTimes {
+		if trip.StopTimes[i].Headsign() != nil {
+			t.Errorf("stop %d: expected nil stop_headsign, got %q", i, *trip.StopTimes[i].Headsign())
+		}
+	}
+}
+
+// TestDuplicateStopNameInTrip: the headsign matches a stop name that appears
+// more than once. The processor iterates backwards and stops at the *last*
+// occurrence, so only stops before that last occurrence get stop_headsign.
+func TestDuplicateStopNameInTrip(t *testing.T) {
+	// Route: Loop → A → B → Loop → End
+	// Headsign "Loop" appears at index 0 and index 3 (0-based).
+	// The backward search finds index 3 first (the last occurrence before
+	// the terminal "End" at index 4).
+	feed := buildFeed("Loop", []string{"Loop", "A", "B", "Loop", "End"})
+	FixIntermediateHeadsigns{}.Run(feed)
+
+	trip := tripOf(feed)
+
+	if *trip.Headsign != "End" {
+		t.Errorf("expected trip headsign %q, got %q", "End", *trip.Headsign)
+	}
+
+	// Stops 0–2 precede matchIndex 3 → should have stop_headsign "Loop".
+	for i := 0; i < 3; i++ {
+		if trip.StopTimes[i].Headsign() == nil || *trip.StopTimes[i].Headsign() != "Loop" {
+			got := "<nil>"
+			if trip.StopTimes[i].Headsign() != nil {
+				got = *trip.StopTimes[i].Headsign()
+			}
+			t.Errorf("stop %d: expected stop_headsign %q, got %q", i, "Loop", got)
+		}
+	}
+
+	// Stops 3 and 4 should have no stop_headsign.
+	for i := 3; i <= 4; i++ {
+		if trip.StopTimes[i].Headsign() != nil {
+			t.Errorf("stop %d: expected nil stop_headsign, got %q", i, *trip.StopTimes[i].Headsign())
+		}
+	}
+}
+
+// TestMultipleTrips: feed with multiple trips; only the one with the buggy
+// headsign should be modified.
+func TestMultipleTrips(t *testing.T) {
+	feed := gtfsparser.NewFeed()
+
+	makeStops := func(names []string) []*gtfs.Stop {
+		out := make([]*gtfs.Stop, len(names))
+		for i, n := range names {
+			n := n
+			s := &gtfs.Stop{Id: n, Name: n}
+			out[i] = s
+			feed.Stops[n] = s
+		}
+		return out
+	}
+
+	addTrip := func(id, headsign string, stops []*gtfs.Stop) {
+		trip := &gtfs.Trip{Id: id, Headsign: makeStr(headsign)}
+		for i, s := range stops {
+			var st gtfs.StopTime
+			st.SetStop(s)
+			st.SetSequence(i + 1)
+			trip.StopTimes = append(trip.StopTimes, st)
+		}
+		feed.Trips[id] = trip
+	}
+
+	// Trip A: buggy headsign (intermediate stop "Bern").
+	stopsA := makeStops([]string{"Zürich", "Bern", "Lausanne"})
+	addTrip("tripA", "Bern", stopsA)
+
+	// Trip B: correct headsign already points to the last stop.
+	stopsB := makeStops([]string{"Basel", "Geneva"})
+	addTrip("tripB", "Geneva", stopsB)
+
+	FixIntermediateHeadsigns{}.Run(feed)
+
+	// tripA should be fixed.
+	tripA := feed.Trips["tripA"]
+	if *tripA.Headsign != "Lausanne" {
+		t.Errorf("tripA: expected headsign %q, got %q", "Lausanne", *tripA.Headsign)
+	}
+	if tripA.StopTimes[0].Headsign() == nil || *tripA.StopTimes[0].Headsign() != "Bern" {
+		t.Errorf("tripA stop 0: expected stop_headsign %q", "Bern")
+	}
+
+	// tripB should be untouched.
+	tripB := feed.Trips["tripB"]
+	if *tripB.Headsign != "Geneva" {
+		t.Errorf("tripB: expected headsign to stay %q, got %q", "Geneva", *tripB.Headsign)
+	}
+	for i := range tripB.StopTimes {
+		if tripB.StopTimes[i].Headsign() != nil {
+			t.Errorf("tripB stop %d: expected nil stop_headsign, got %q", i, *tripB.StopTimes[i].Headsign())
+		}
+	}
+}
+
+// TestHeadsignMatchesFirstStop: headsign matches index 0 — matchIndex is 0,
+// so no stops precede it and no stop_headsigns should be applied, but the
+// trip headsign still gets updated.
+func TestHeadsignMatchesFirstStop(t *testing.T) {
+	feed := buildFeed("Alpha", []string{"Alpha", "Beta", "Gamma"})
+	FixIntermediateHeadsigns{}.Run(feed)
+
+	trip := tripOf(feed)
+	if *trip.Headsign != "Gamma" {
+		t.Errorf("expected trip headsign %q, got %q", "Gamma", *trip.Headsign)
+	}
+	for i := range trip.StopTimes {
+		if trip.StopTimes[i].Headsign() != nil {
+			t.Errorf("stop %d: expected nil stop_headsign, got %q", i, *trip.StopTimes[i].Headsign())
+		}
+	}
+}


### PR DESCRIPTION
In the Swiss GTFS Instance, there is a data-bug where the trip_headsign is set to the stop_name of a stop along the trip, but not the last stop. An example is this S4 (screenshot from travic.app):

<img width="1618" height="1091" alt="Screenshot 2026-01-10 at 12 23 09" src="https://github.com/user-attachments/assets/e9af33b4-c834-4ced-8dba-4f413a697b8f" />

The train stops at "St. Gallen", but then continues and the trip headsign is somewhat confusing (because the train left "St. Gallen", and is heading to another stop (in this case: "Rapperswil SG").

This PR fixes this, by checking whether the trip headsign matches the name of an intermediate stop along its journey, and if yes, set the orignal trip headsign as stop_headsign, and replaces the trip headsign by the name of the last stop.